### PR TITLE
Fix indentation in Python script

### DIFF
--- a/krcert_parsing.py
+++ b/krcert_parsing.py
@@ -55,7 +55,7 @@ def krcert():
 
 def main():
     temp = krcert()
-	print(temp)
+    print(temp)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- fix mixed tab/space indentation in `krcert_parsing.py`

## Testing
- `python3 krcert_parsing.py` *(fails: ModuleNotFoundError: No module named 'httplib2')*
- `pip install httplib2` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683ff632fb1c832b962ec4614a32d49b